### PR TITLE
Remove inline-block

### DIFF
--- a/chat.css
+++ b/chat.css
@@ -52,7 +52,6 @@
 	line-height: 24px;
 	white-space: -o-pre-wrap; /* Opera */
 	word-wrap: break-word; /* Internet Explorer 5.5+ */
-	display: inline-block;
 }
 
 .message-pane li>div p {


### PR DESCRIPTION
the chat currently has "display: inline-block" rule which breaks some other css rules. for example: the timestamp is broken but is now fixed after removing this rule

this just removes that flag and fixes the problem